### PR TITLE
Bug in the examples.

### DIFF
--- a/examples/demo_hb_mc21.py
+++ b/examples/demo_hb_mc21.py
@@ -27,7 +27,7 @@ print 'Number of nonzeros on diagonal after reordering: ', nzdiag
 try:
     from pyorder.tools.spy import FastSpy
     import pylab
-    (irow, jcol) = M.find()
+    (_, irow, jcol) = M.find()
     left = pylab.subplot(121)
     FastSpy(M.nrow, M.ncol, irow, jcol, sym=M.issym, ax=left.get_axes())
 

--- a/examples/demo_hb_mc60.py
+++ b/examples/demo_hb_mc60.py
@@ -25,8 +25,9 @@ perm, rinfo = rcmk(M.nrow, M.ind, M.ip)
 # Or: Compute Sloan's ordering
 #perm, rinfo = sloan(M.nrow, M.ind, M.ip)
 
+
 # Plot original matrix
-(irow, jcol) = M.find()
+(_, irow, jcol) = M.find()
 left = pylab.subplot(121)
 FastSpy(M.nrow, M.ncol, irow, jcol, sym=M.issym,
         ax=left.get_axes(), title='Original')

--- a/examples/demo_hb_mc60_pro.py
+++ b/examples/demo_hb_mc60_pro.py
@@ -69,7 +69,7 @@ try:
     import pylab
     from pyorder.tools.spy import FastSpy
     # Plot original matrix
-    (irow, jcol) = M.find()
+    (_, irow, jcol) = M.find()
     left = pylab.subplot(121)
     right = pylab.subplot(122)
     FastSpy(M.nrow, M.ncol, irow, jcol, sym=M.issym,


### PR DESCRIPTION
There was a bug in the examples. `find()` function from `hrb` returns 3 values not 2.
